### PR TITLE
Atualização do Makefile Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ setup:
 	python manage.py loaddata onecloud/fixtures/users.json
 
 dev:
-	python manage.py jenkins --pep8-exclude="*migrations*" --pep8-max-line-length=160 --pep8-ignore=E128
+	python manage.py jenkins --pep8-exclude="*migrations*"


### PR DESCRIPTION
Alteração na execução do jenkins. Agora, é passado o parâmetro --pep8-exclude="_migrations_"
